### PR TITLE
Do not use absolute path for minikube, fixes #1047 for 6.0 branch

### DIFF
--- a/test/framework/ingress_util.go
+++ b/test/framework/ingress_util.go
@@ -328,7 +328,7 @@ func getLoadBalancerURLs(provider string, k kubernetes.Interface, ing *api_v1bet
 		gomega.Eventually(func() error {
 			var outputs []byte
 			outputs, err = exec.Command(
-				"/usr/local/bin/minikube",
+				"minikube",
 				"service",
 				ing.OffshootName(),
 				"--url",


### PR DESCRIPTION
Fixes #1047