### PR TITLE
fix CheckCertificates goroutine to run an infinite loop again

### DIFF
--- a/pkg/operator/certificate_crds.go
+++ b/pkg/operator/certificate_crds.go
@@ -139,7 +139,8 @@ func (op *Operator) reconcileCertificate(key string) error {
 
 func (op *Operator) CheckCertificates() {
 	Time := clock.New()
-	for range Time.After(time.Minute * 5) {
+	for {
+		<-Time.After(time.Minute * 5)
 		result, err := op.crtLister.List(labels.Everything())
 		if err != nil {
 			log.Error(err)


### PR DESCRIPTION
The `CheckCertificates` goroutine should run an infinite loop, running one iteration every 5 minutes, to ensure certificates are correctly generated and never expire. 

Release v1.12.0 introduced a bug (#1522) which was making this goroutine run only once (after 5 minutes), and then block forever. Indeed, a `for range` loop receives values from the channel repeatedly until it is closed. And `Time.After` waits for 5 minutes and then sends the current time on the returned channel, but then neither sends any other value nor closes the channel, so it just blocks forever. 

Instead, just use an infinite loop that waits for `Time.After` to send its value, then end the iteration and let a new one start (more or less like it was in v1.11.1 and before). 