### PR TITLE
Avoid issuing cert two times at creation

### DIFF
--- a/pkg/operator/certificate_crds.go
+++ b/pkg/operator/certificate_crds.go
@@ -152,6 +152,11 @@ func (op *Operator) CheckCertificates() {
 				continue
 			}
 
+			if cert.CreationTimestamp.Time.After(time.Now().Add(-5 * time.Minute)) {
+				glog.Infof("Cert %s created less than 5 min ago, skipping check", cert.Name)
+				continue
+			}
+
 			if cert.IsRateLimited() {
 				// get a new account and retry
 				s := metav1.ObjectMeta{


### PR DESCRIPTION
This PR fixes another bug with certificates creation, that has been in Voyager for a long time. 

When you create a new certificate (or update an existing one, or restart `voyager-operator`), the `reconcileCertificate` function will be called instantly, trying to issue that certificate (if needed). In my case (DNS challenge), it takes approximately one minute to obtain the certificate (need to add the TXT record, check propagation, wait for LE to issue it...)

Meanwhile, there is a goroutine looping (one iteration every 5 minutes): `CheckCertificates`. That goroutine will often try to issue the same certificate at the same time. And that can cause a lot of different bugs with different providers. 

For example, with `gcloud`, I always get the `alreadyExists` error, because the TXT record already exists (via `reconcileCertificate`), and via `CheckCertificates`, `appscode/lego` tries to delete the TXT record before re-creating it, but it actually does both at the same time, so `gcloud` refuses the addition since it doesn't occur *after* the deletion. Note that this particular bug has been fixed in `go-acme/lego` which is the successor of `xenolf/lego` (`appscode/lego` is a 2018 fork of `xenolf/lego`). If you backmerge the master branch of `go-acme/lego` into `appscode/lego`, then it should fix that bug, and probably a few others (but it has changed quite a lot since the fork so I couldn't really do it myself). 

But anyway, with this PR you will most of the time dodge that bug since concurrent updates should almost never happen (note that there is a 3 minutes timeout when you issue a certificate). And it also fixes bugs with other providers than `gcloud`, e.g. with `ovh` I got other errors like "incorrect TXT record" that are due to the same concurrency problems. And they should also disappear with this PR. 