### PR TITLE
Avoid concurrent haproxy starts or reloads

### DIFF
--- a/pkg/haproxy/controller/controller.go
+++ b/pkg/haproxy/controller/controller.go
@@ -288,12 +288,7 @@ func (c *Controller) Run(stopCh chan struct{}) {
 	defer ticker.Stop()
 	go func() {
 		for range ticker.C {
-			if _, err := checkHAProxyDaemon(); err != nil {
-				glog.Error(err)
-				if err = startHAProxy(); err != nil {
-					glog.Error(err)
-				}
-			}
+			startHaproxyIfNeeded()
 		}
 	}()
 


### PR DESCRIPTION
This PR fixes #1334. 
As _elynnyap_ explained, the "503  errors" bug is actually caused by several haproxy processes running in parallel. 
This can happen when several `haproxy` commands are executed at the same time. 

In `controller.go` (`Run`), there is a 30 seconds ticker that checks if the haproxy daemon exists, and if it doesn't, it starts a new one, otherwise it does nothing. 
To determine whether the process exists or not, it reads `/var/run/haproxy.pid`, and then tries to find a process with that pid. 

But in `reload.go`, there is another function `startOrReloadHaproxy` that is called whenever there is a config/cert change. It does the same daemon existence check, and then either starts a new haproxy, or reloads the existing one. 

The bug occurs when both execute at the same time. At the moment `startOrReloadHaproxy` reloads the current process, the background ticker will get an `error reading haproxy.pid file`, assume it is crashed, and start a new one. At that point, we have two haproxy processes: one of them has the most recent config, and the other one is outdated forever. Some requests will be served by one of them, some by the other, which explains the non-deterministic behaviour of those 503 errors. At that point, the only solution is to kill the oldest haproxy process. 

My fix is simply to use a mutex before checking haproxy daemon, and release it after starting/reloading haproxy, so we make sure two `haproxy` commands are never executed at the same time. 