### PR TITLE
Prepare for release v2021.10.16

### DIFF
--- a/docs/CHANGELOG-v2021.10.16.md
+++ b/docs/CHANGELOG-v2021.10.16.md
@@ -1,0 +1,60 @@
+---
+title: Changelog | Voyager
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-voyager-v2021.10.16
+    name: Changelog-v2021.10.16
+    parent: welcome
+    weight: 20211016
+product_name: voyager
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2021.10.16/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2021.10.16/
+---
+
+# Voyager v2021.10.16 (2021-10-16)
+
+
+## [voyagermesh/apimachinery](https://github.com/voyagermesh/apimachinery)
+
+### [v0.1.1](https://github.com/voyagermesh/apimachinery/releases/tag/v0.1.1)
+
+- [a7704e79](https://github.com/voyagermesh/apimachinery/commit/a7704e79) Set TypeMeta for converter methods (#15)
+- [2ccd9780](https://github.com/voyagermesh/apimachinery/commit/2ccd9780) Fix jwt-go security vulnerability (#14)
+- [7c884131](https://github.com/voyagermesh/apimachinery/commit/7c884131) Fix jwt-go security vulnerability (#13)
+- [660e4478](https://github.com/voyagermesh/apimachinery/commit/660e4478) Update dependencies to publish SiteInfo (#12)
+- [c175c94c](https://github.com/voyagermesh/apimachinery/commit/c175c94c) Update repository config (#11)
+- [aabe0c90](https://github.com/voyagermesh/apimachinery/commit/aabe0c90) Rename minikube to kind (#10)
+- [4216e746](https://github.com/voyagermesh/apimachinery/commit/4216e746) Remove deprecated fields (#9)
+
+
+
+## [voyagermesh/haproxy-ingress](https://github.com/voyagermesh/haproxy-ingress)
+
+### [v13.0.1](https://github.com/voyagermesh/haproxy-ingress/releases/tag/v13.0.1)
+
+- [1f65f08c](https://github.com/voyagermesh/haproxy-ingress/commit/1f65f08c) Prepare for release v13.0.1 (#24)
+- [89dcd122](https://github.com/voyagermesh/haproxy-ingress/commit/89dcd122) Run separate operator and webhook server pods (#23)
+- [f5621d0d](https://github.com/voyagermesh/haproxy-ingress/commit/f5621d0d) Fix jwt-go security vulnerability (#21)
+- [b968bc02](https://github.com/voyagermesh/haproxy-ingress/commit/b968bc02) Use nats.go v1.13.0 (#20)
+- [e3c0c421](https://github.com/voyagermesh/haproxy-ingress/commit/e3c0c421) Setup SiteInfo publisher (#19)
+- [5a3f21d3](https://github.com/voyagermesh/haproxy-ingress/commit/5a3f21d3) Update dependencies to publish SiteInfo (#18)
+
+
+
+## [voyagermesh/installer](https://github.com/voyagermesh/installer)
+
+### [v2021.10.16](https://github.com/voyagermesh/installer/releases/tag/v2021.10.16)
+
+- [c609411](https://github.com/voyagermesh/installer/commit/c609411) Prepare for release v2021.10.16 (#91)
+- [66bc3ad](https://github.com/voyagermesh/installer/commit/66bc3ad) Use separate deployments for operator and webhook server (#90)
+- [b2d8453](https://github.com/voyagermesh/installer/commit/b2d8453) Fix jwt-go security vulnerability (#89)
+- [de86de2](https://github.com/voyagermesh/installer/commit/de86de2) Update dependencies to publish SiteInfo (#88)
+- [0e722e0](https://github.com/voyagermesh/installer/commit/0e722e0) Update repository config (#87)
+
+
+
+


### PR DESCRIPTION
ProductLine: Voyager
Release: v2021.10.16
Release-tracker: https://github.com/voyagermesh/CHANGELOG/pull/8
Signed-off-by: 1gtm <1gtm@appscode.com>