### PR TITLE
Prepare for release v2021.10.17

### DIFF
--- a/docs/CHANGELOG-v2021.10.17.md
+++ b/docs/CHANGELOG-v2021.10.17.md
@@ -1,0 +1,47 @@
+---
+title: Changelog | Voyager
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-voyager-v2021.10.17
+    name: Changelog-v2021.10.17
+    parent: welcome
+    weight: 20211017
+product_name: voyager
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2021.10.17/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2021.10.17/
+---
+
+# Voyager v2021.10.17 (2021-10-16)
+
+
+## [voyagermesh/apimachinery](https://github.com/voyagermesh/apimachinery)
+
+### [v0.1.2](https://github.com/voyagermesh/apimachinery/releases/tag/v0.1.2)
+
+- [1e37c726](https://github.com/voyagermesh/apimachinery/commit/1e37c726) Recover from conversion panic (#16)
+
+
+
+## [voyagermesh/haproxy-ingress](https://github.com/voyagermesh/haproxy-ingress)
+
+### [v13.0.2](https://github.com/voyagermesh/haproxy-ingress/releases/tag/v13.0.2)
+
+- [dab93b5e](https://github.com/voyagermesh/haproxy-ingress/commit/dab93b5e) Prepare for release v13.0.2 (#26)
+- [42ef435b](https://github.com/voyagermesh/haproxy-ingress/commit/42ef435b) Log ensure crd error without failing operator (#25)
+- [29e080ba](https://github.com/voyagermesh/haproxy-ingress/commit/29e080ba) Fix flag conflict
+
+
+
+## [voyagermesh/installer](https://github.com/voyagermesh/installer)
+
+### [v2021.10.17](https://github.com/voyagermesh/installer/releases/tag/v2021.10.17)
+
+- [a92784d](https://github.com/voyagermesh/installer/commit/a92784d) Prepare for release v2021.10.17 (#92)
+
+
+
+


### PR DESCRIPTION
ProductLine: Voyager
Release: v2021.10.17
Release-tracker: https://github.com/voyagermesh/CHANGELOG/pull/9
Signed-off-by: 1gtm <1gtm@appscode.com>