### PR TITLE
Prepare for release v2021.10.18

### DIFF
--- a/docs/CHANGELOG-v2021.10.18.md
+++ b/docs/CHANGELOG-v2021.10.18.md
@@ -1,0 +1,59 @@
+---
+title: Changelog | Voyager
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-voyager-v2021.10.18
+    name: Changelog-v2021.10.18
+    parent: welcome
+    weight: 20211018
+product_name: voyager
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2021.10.18/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2021.10.18/
+---
+
+# Voyager v2021.10.18 (2021-10-18)
+
+
+## [voyagermesh/apimachinery](https://github.com/voyagermesh/apimachinery)
+
+### [v0.1.3](https://github.com/voyagermesh/apimachinery/releases/tag/v0.1.3)
+
+- [21c78451](https://github.com/voyagermesh/apimachinery/commit/21c78451) Fix v1beta1 to v1 type conversion (#17)
+- [1fcd5596](https://github.com/voyagermesh/apimachinery/commit/1fcd5596) Remove kubectl.kubernetes.io/last-applied-configuration annotation
+
+
+
+## [voyagermesh/cli](https://github.com/voyagermesh/cli)
+
+### [v0.0.3](https://github.com/voyagermesh/cli/releases/tag/v0.0.3)
+
+- [115ccc1](https://github.com/voyagermesh/cli/commit/115ccc1) Prepare for release v0.0.3 (#2)
+
+
+
+## [voyagermesh/haproxy-ingress](https://github.com/voyagermesh/haproxy-ingress)
+
+### [v13.0.3](https://github.com/voyagermesh/haproxy-ingress/releases/tag/v13.0.3)
+
+- [bf746ef6](https://github.com/voyagermesh/haproxy-ingress/commit/bf746ef6) Prepare for release v13.0.3 (#30)
+- [73778780](https://github.com/voyagermesh/haproxy-ingress/commit/73778780) Remove check and convert commands
+- [5755c97e](https://github.com/voyagermesh/haproxy-ingress/commit/5755c97e) Move reference docs to a sub menu (#29)
+- [8e5ab525](https://github.com/voyagermesh/haproxy-ingress/commit/8e5ab525) Load HAProxy templates using git submodule (#28)
+- [69192031](https://github.com/voyagermesh/haproxy-ingress/commit/69192031) Add haproxy-templates git submodule
+- [0f4310a6](https://github.com/voyagermesh/haproxy-ingress/commit/0f4310a6) Fix conversion panic (#27)
+
+
+
+## [voyagermesh/installer](https://github.com/voyagermesh/installer)
+
+### [v2021.10.18](https://github.com/voyagermesh/installer/releases/tag/v2021.10.18)
+
+- [7a4972c](https://github.com/voyagermesh/installer/commit/7a4972c) Prepare for release v2021.10.18 (#93)
+
+
+
+


### PR DESCRIPTION
ProductLine: Voyager
Release: v2021.10.18
Release-tracker: https://github.com/voyagermesh/CHANGELOG/pull/10
Signed-off-by: 1gtm <1gtm@appscode.com>