### PR TITLE
Prepare for release v2022.01.01

### DIFF
--- a/docs/CHANGELOG-v2022.01.01.md
+++ b/docs/CHANGELOG-v2022.01.01.md
@@ -1,0 +1,66 @@
+---
+title: Changelog | Voyager
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-voyager-v2022.01.01
+    name: Changelog-v2022.01.01
+    parent: welcome
+    weight: 20220101
+product_name: voyager
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2022.01.01/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2022.01.01/
+---
+
+# Voyager v2022.01.01 (2022-01-02)
+
+
+## [voyagermesh/apimachinery](https://github.com/voyagermesh/apimachinery)
+
+### [v0.2.0](https://github.com/voyagermesh/apimachinery/releases/tag/v0.2.0)
+
+- [b9ccd598](https://github.com/voyagermesh/apimachinery/commit/b9ccd598) Support proxy security context (#21)
+- [1991e135](https://github.com/voyagermesh/apimachinery/commit/1991e135) Update repository config (#20)
+- [0393f8de](https://github.com/voyagermesh/apimachinery/commit/0393f8de) Update repository config (#19)
+- [f792df1d](https://github.com/voyagermesh/apimachinery/commit/f792df1d) Fix satori/go.uuid security vulnerability (#18)
+
+
+
+## [voyagermesh/cli](https://github.com/voyagermesh/cli)
+
+### [v0.0.4](https://github.com/voyagermesh/cli/releases/tag/v0.0.4)
+
+- [7ee2d31](https://github.com/voyagermesh/cli/commit/7ee2d31) Prepare for release v0.0.4 (#3)
+- [979d215](https://github.com/voyagermesh/cli/commit/979d215) Correctly initialize klog flags
+
+
+
+## [voyagermesh/haproxy-ingress](https://github.com/voyagermesh/haproxy-ingress)
+
+### [v14.0.0](https://github.com/voyagermesh/haproxy-ingress/releases/tag/v14.0.0)
+
+- [cdb54de8](https://github.com/voyagermesh/haproxy-ingress/commit/cdb54de8) Prepare for release v14.0.0 (#34)
+- [e591ca27](https://github.com/voyagermesh/haproxy-ingress/commit/e591ca27) Log changed files when haproxy is reloaded (#33)
+- [83a3b1f0](https://github.com/voyagermesh/haproxy-ingress/commit/83a3b1f0) Various cleanup (#32)
+- [1be18011](https://github.com/voyagermesh/haproxy-ingress/commit/1be18011) Update configreader
+- [77b702a2](https://github.com/voyagermesh/haproxy-ingress/commit/77b702a2) Fix satori/go.uuid security vulnerability (#31)
+- [b371aae6](https://github.com/voyagermesh/haproxy-ingress/commit/b371aae6) update templates
+
+
+
+## [voyagermesh/installer](https://github.com/voyagermesh/installer)
+
+### [v2022.01.01](https://github.com/voyagermesh/installer/releases/tag/v2022.01.01)
+
+- [0d683d5](https://github.com/voyagermesh/installer/commit/0d683d5) Prepare for release v2022.01.01 (#97)
+- [3583265](https://github.com/voyagermesh/installer/commit/3583265) Remove enableAnalytics flag
+- [21e6643](https://github.com/voyagermesh/installer/commit/21e6643) Update default HAProxy version to 2.5.0 (#96)
+- [c3f75c3](https://github.com/voyagermesh/installer/commit/c3f75c3) Update repository config (#95)
+- [2a22b46](https://github.com/voyagermesh/installer/commit/2a22b46) Fix satori/go.uuid security vulnerability (#94)
+
+
+
+


### PR DESCRIPTION
ProductLine: Voyager
Release: v2022.01.01
Release-tracker: https://github.com/voyagermesh/CHANGELOG/pull/11
Signed-off-by: 1gtm <1gtm@appscode.com>