### PR TITLE
Prepare for release v2022.01.07

### DIFF
--- a/docs/CHANGELOG-v2022.01.07.md
+++ b/docs/CHANGELOG-v2022.01.07.md
@@ -1,0 +1,39 @@
+---
+title: Changelog | Voyager
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-voyager-v2022.01.07
+    name: Changelog-v2022.01.07
+    parent: welcome
+    weight: 20220107
+product_name: voyager
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2022.01.07/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2022.01.07/
+---
+
+# Voyager v2022.01.07 (2022-01-07)
+
+
+## [voyagermesh/haproxy-ingress](https://github.com/voyagermesh/haproxy-ingress)
+
+### [v14.0.1](https://github.com/voyagermesh/haproxy-ingress/releases/tag/v14.0.1)
+
+- [f9861aed](https://github.com/voyagermesh/haproxy-ingress/commit/f9861aed) Log diffs for changed config files (#36)
+- [ddcf94de](https://github.com/voyagermesh/haproxy-ingress/commit/ddcf94de) Run trivy scanner (#35)
+
+
+
+## [voyagermesh/installer](https://github.com/voyagermesh/installer)
+
+### [v2022.01.07](https://github.com/voyagermesh/installer/releases/tag/v2022.01.07)
+
+- [912f293](https://github.com/voyagermesh/installer/commit/912f293) Prepare for release v2022.01.07 (#98)
+- [63c4565](https://github.com/voyagermesh/installer/commit/63c4565) Enable arm64 nodes by default
+
+
+
+


### PR DESCRIPTION
ProductLine: Voyager
Release: v2022.01.07
Release-tracker: https://github.com/voyagermesh/CHANGELOG/pull/12
Signed-off-by: 1gtm <1gtm@appscode.com>