### PR TITLE
Prepare for release v2022.01.10

### DIFF
--- a/docs/CHANGELOG-v2022.01.10.md
+++ b/docs/CHANGELOG-v2022.01.10.md
@@ -1,0 +1,56 @@
+---
+title: Changelog | Voyager
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-voyager-v2022.01.10
+    name: Changelog-v2022.01.10
+    parent: welcome
+    weight: 20220110
+product_name: voyager
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2022.01.10/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2022.01.10/
+---
+
+# Voyager v2022.01.10 (2022-01-10)
+
+
+## [voyagermesh/apimachinery](https://github.com/voyagermesh/apimachinery)
+
+### [v0.3.0](https://github.com/voyagermesh/apimachinery/releases/tag/v0.3.0)
+
+- [7d6c4d04](https://github.com/voyagermesh/apimachinery/commit/7d6c4d04) Convert ProxySecurityContext from v1beta1 to v1 api (#22)
+
+
+
+## [voyagermesh/cli](https://github.com/voyagermesh/cli)
+
+### [v0.0.5](https://github.com/voyagermesh/cli/releases/tag/v0.0.5)
+
+- [1824d2f](https://github.com/voyagermesh/cli/commit/1824d2f) Prepare for release v0.0.5 (#4)
+
+
+
+## [voyagermesh/haproxy-ingress](https://github.com/voyagermesh/haproxy-ingress)
+
+### [v14.1.0](https://github.com/voyagermesh/haproxy-ingress/releases/tag/v14.1.0)
+
+- [96ea81cb](https://github.com/voyagermesh/haproxy-ingress/commit/96ea81cb) Prepare for release v14.1.0 (#38)
+- [9df118f9](https://github.com/voyagermesh/haproxy-ingress/commit/9df118f9) Mount emptyDir to /var/run (#37)
+- [b48d48f9](https://github.com/voyagermesh/haproxy-ingress/commit/b48d48f9) Use HAProxy 2.5 (no patch) version
+
+
+
+## [voyagermesh/installer](https://github.com/voyagermesh/installer)
+
+### [v2022.01.10](https://github.com/voyagermesh/installer/releases/tag/v2022.01.10)
+
+- [dac9c9b](https://github.com/voyagermesh/installer/commit/dac9c9b) Prepare for release v2022.01.10 (#100)
+- [40a8b9a](https://github.com/voyagermesh/installer/commit/40a8b9a) Use HAProxy 2.5-alpine version (#99)
+
+
+
+


### PR DESCRIPTION
ProductLine: Voyager
Release: v2022.01.10
Release-tracker: https://github.com/voyagermesh/CHANGELOG/pull/13
Signed-off-by: 1gtm <1gtm@appscode.com>