### PR TITLE
Prepare for release v2022.02.22

### DIFF
--- a/docs/CHANGELOG-v2022.02.22.md
+++ b/docs/CHANGELOG-v2022.02.22.md
@@ -1,0 +1,59 @@
+---
+title: Changelog | Voyager
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-voyager-v2022.02.22
+    name: Changelog-v2022.02.22
+    parent: welcome
+    weight: 20220222
+product_name: voyager
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2022.02.22/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2022.02.22/
+---
+
+# Voyager v2022.02.22 (2022-02-18)
+
+
+## [voyagermesh/apimachinery](https://github.com/voyagermesh/apimachinery)
+
+### [v0.4.0](https://github.com/voyagermesh/apimachinery/releases/tag/v0.4.0)
+
+- [1f3d5fa1](https://github.com/voyagermesh/apimachinery/commit/1f3d5fa1) Update SiteInfo (#24)
+- [54c9652d](https://github.com/voyagermesh/apimachinery/commit/54c9652d) Update repository config (#23)
+
+
+
+## [voyagermesh/cli](https://github.com/voyagermesh/cli)
+
+### [v0.0.6](https://github.com/voyagermesh/cli/releases/tag/v0.0.6)
+
+- [0adaf81](https://github.com/voyagermesh/cli/commit/0adaf81) Prepare for release v0.0.6 (#5)
+
+
+
+## [voyagermesh/haproxy-ingress](https://github.com/voyagermesh/haproxy-ingress)
+
+### [v14.2.0](https://github.com/voyagermesh/haproxy-ingress/releases/tag/v14.2.0)
+
+- [1e0fe986](https://github.com/voyagermesh/haproxy-ingress/commit/1e0fe986) Prepare for release v14.2.0 (#41)
+- [42297611](https://github.com/voyagermesh/haproxy-ingress/commit/42297611) Publish GenericResource event (#40)
+- [90e4b8c3](https://github.com/voyagermesh/haproxy-ingress/commit/90e4b8c3) Update SiteInfo (#39)
+
+
+
+## [voyagermesh/installer](https://github.com/voyagermesh/installer)
+
+### [v2022.02.22](https://github.com/voyagermesh/installer/releases/tag/v2022.02.22)
+
+- [ee7b622](https://github.com/voyagermesh/installer/commit/ee7b622) Prepare for release v2022.02.22 (#105)
+- [bfb6acb](https://github.com/voyagermesh/installer/commit/bfb6acb) Update repository config (#104)
+- [c171823](https://github.com/voyagermesh/installer/commit/c171823) Use well-known os label (#103)
+- [d1d214e](https://github.com/voyagermesh/installer/commit/d1d214e) Update SiteInfo (#102)
+
+
+
+


### PR DESCRIPTION
ProductLine: Voyager
Release: v2022.02.22
Release-tracker: https://github.com/voyagermesh/CHANGELOG/pull/14
Signed-off-by: 1gtm <1gtm@appscode.com>