### PR TITLE
Prepare for release v2022.03.17

### DIFF
--- a/docs/CHANGELOG-v2022.03.17.md
+++ b/docs/CHANGELOG-v2022.03.17.md
@@ -1,0 +1,56 @@
+---
+title: Changelog | Voyager
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-voyager-v2022.03.17
+    name: Changelog-v2022.03.17
+    parent: welcome
+    weight: 20220317
+product_name: voyager
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2022.03.17/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2022.03.17/
+---
+
+# Voyager v2022.03.17 (2022-03-17)
+
+
+## [voyagermesh/cli](https://github.com/voyagermesh/cli)
+
+### [v0.0.7](https://github.com/voyagermesh/cli/releases/tag/v0.0.7)
+
+- [16d852a](https://github.com/voyagermesh/cli/commit/16d852a) Prepare for release v0.0.7 (#8)
+- [8b0b309](https://github.com/voyagermesh/cli/commit/8b0b309) Build darwin/arm64 images
+- [b68c523](https://github.com/voyagermesh/cli/commit/b68c523) Use Go 1.18 (#7)
+- [0bc96a7](https://github.com/voyagermesh/cli/commit/0bc96a7) make fmt (#6)
+
+
+
+## [voyagermesh/haproxy-ingress](https://github.com/voyagermesh/haproxy-ingress)
+
+### [v14.2.1](https://github.com/voyagermesh/haproxy-ingress/releases/tag/v14.2.1)
+
+- [73961286](https://github.com/voyagermesh/haproxy-ingress/commit/73961286) Prepare for release v14.2.1 (#46)
+- [c9319f58](https://github.com/voyagermesh/haproxy-ingress/commit/c9319f58) Use Go 1.18 (#43)
+- [56e996e9](https://github.com/voyagermesh/haproxy-ingress/commit/56e996e9) Fix CVEs reported in trivy scanner (#45)
+- [6609a2e3](https://github.com/voyagermesh/haproxy-ingress/commit/6609a2e3) git submodule updated
+- [cc3ccde8](https://github.com/voyagermesh/haproxy-ingress/commit/cc3ccde8) make fmt (#42)
+
+
+
+## [voyagermesh/installer](https://github.com/voyagermesh/installer)
+
+### [v2022.03.17](https://github.com/voyagermesh/installer/releases/tag/v2022.03.17)
+
+- [f9d677a](https://github.com/voyagermesh/installer/commit/f9d677a) Prepare for release v2022.03.17 (#109)
+- [a1e348f](https://github.com/voyagermesh/installer/commit/a1e348f) Use k8s 1.23.3 in ci
+- [e1f4155](https://github.com/voyagermesh/installer/commit/e1f4155) Use Go 1.18 (#107)
+- [68be613](https://github.com/voyagermesh/installer/commit/68be613) Fix chart schema (#108)
+- [4bcfebc](https://github.com/voyagermesh/installer/commit/4bcfebc) make fmt (#106)
+
+
+
+


### PR DESCRIPTION
ProductLine: Voyager
Release: v2022.03.17
Release-tracker: https://github.com/voyagermesh/CHANGELOG/pull/17
Signed-off-by: 1gtm <1gtm@appscode.com>