### PR TITLE
Prepare for release v2022.04.13

### DIFF
--- a/docs/CHANGELOG-v2022.04.13.md
+++ b/docs/CHANGELOG-v2022.04.13.md
@@ -1,0 +1,54 @@
+---
+title: Changelog | Voyager
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-voyager-v2022.04.13
+    name: Changelog-v2022.04.13
+    parent: welcome
+    weight: 20220413
+product_name: voyager
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2022.04.13/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2022.04.13/
+---
+
+# Voyager v2022.04.13 (2022-04-14)
+
+
+## [voyagermesh/apimachinery](https://github.com/voyagermesh/apimachinery)
+
+### [v0.4.2](https://github.com/voyagermesh/apimachinery/releases/tag/v0.4.2)
+
+- [0eb8cb31](https://github.com/voyagermesh/apimachinery/commit/0eb8cb31) Use Go 1.18 (#27)
+
+
+
+## [voyagermesh/cli](https://github.com/voyagermesh/cli)
+
+### [v0.0.8](https://github.com/voyagermesh/cli/releases/tag/v0.0.8)
+
+- [70b38ac](https://github.com/voyagermesh/cli/commit/70b38ac) Prepare for release v0.0.8 (#9)
+
+
+
+## [voyagermesh/haproxy-ingress](https://github.com/voyagermesh/haproxy-ingress)
+
+### [v14.2.2](https://github.com/voyagermesh/haproxy-ingress/releases/tag/v14.2.2)
+
+- [8182f293](https://github.com/voyagermesh/haproxy-ingress/commit/8182f293) Prepare for release v14.2.2 (#47)
+- [91478824](https://github.com/voyagermesh/haproxy-ingress/commit/91478824) Add scanner
+
+
+
+## [voyagermesh/installer](https://github.com/voyagermesh/installer)
+
+### [v2022.04.13](https://github.com/voyagermesh/installer/releases/tag/v2022.04.13)
+
+- [2172ee0](https://github.com/voyagermesh/installer/commit/2172ee0) Prepare for release v2022.04.13 (#110)
+
+
+
+


### PR DESCRIPTION
ProductLine: Voyager
Release: v2022.04.13
Release-tracker: https://github.com/voyagermesh/CHANGELOG/pull/18
Signed-off-by: 1gtm <1gtm@appscode.com>