### PR TITLE
Prepare for release v2022.06.20

### DIFF
--- a/docs/CHANGELOG-v2022.06.20.md
+++ b/docs/CHANGELOG-v2022.06.20.md
@@ -1,0 +1,63 @@
+---
+title: Changelog | Voyager
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-voyager-v2022.06.20
+    name: Changelog-v2022.06.20
+    parent: welcome
+    weight: 20220620
+product_name: voyager
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2022.06.20/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2022.06.20/
+---
+
+# Voyager v2022.06.20 (2022-06-17)
+
+
+## [voyagermesh/apimachinery](https://github.com/voyagermesh/apimachinery)
+
+### [v0.5.0](https://github.com/voyagermesh/apimachinery/releases/tag/v0.5.0)
+
+- [9a6e26b7](https://github.com/voyagermesh/apimachinery/commit/9a6e26b7) Update to k8s 1.24 toolchain (#29)
+- [6bfee384](https://github.com/voyagermesh/apimachinery/commit/6bfee384) Test against Kubernetes 1.24.0 (#28)
+
+
+
+## [voyagermesh/cli](https://github.com/voyagermesh/cli)
+
+### [v0.0.9](https://github.com/voyagermesh/cli/releases/tag/v0.0.9)
+
+- [696408d](https://github.com/voyagermesh/cli/commit/696408d) Prepare for release v0.0.9 (#11)
+- [7b82992](https://github.com/voyagermesh/cli/commit/7b82992) Update to k8s 1.24 toolchain (#10)
+
+
+
+## [voyagermesh/haproxy-ingress](https://github.com/voyagermesh/haproxy-ingress)
+
+### [v15.0.0](https://github.com/voyagermesh/haproxy-ingress/releases/tag/v15.0.0)
+
+- [b9b68401](https://github.com/voyagermesh/haproxy-ingress/commit/b9b684018) Prepare for release v15.0.0 (#51)
+- [804b350d](https://github.com/voyagermesh/haproxy-ingress/commit/804b350d9) Fix port detection for external name type service (#50)
+- [126137a9](https://github.com/voyagermesh/haproxy-ingress/commit/126137a90) Fix CVE-2022-1586 CVE-2022-1587
+- [0a61fc9c](https://github.com/voyagermesh/haproxy-ingress/commit/0a61fc9c4) Update to k8s 1.24 toolchain (#49)
+- [46b78cfe](https://github.com/voyagermesh/haproxy-ingress/commit/46b78cfed) Test against Kubernetes 1.24.0 (#48)
+
+
+
+## [voyagermesh/installer](https://github.com/voyagermesh/installer)
+
+### [v2022.06.20](https://github.com/voyagermesh/installer/releases/tag/v2022.06.20)
+
+- [61e1f75](https://github.com/voyagermesh/installer/commit/61e1f75) Prepare for release v2022.06.20 (#113)
+- [d207168](https://github.com/voyagermesh/installer/commit/d207168) Get operator from chart appVersion
+- [9bc4b6c](https://github.com/voyagermesh/installer/commit/9bc4b6c) Update to k8s 1.24 toolchain (#112)
+- [84ab347](https://github.com/voyagermesh/installer/commit/84ab347) Test against Kubernetes 1.24.0 (#111)
+- [02028da](https://github.com/voyagermesh/installer/commit/02028da) Change MY_POD_ env prefix to POD_
+
+
+
+


### PR DESCRIPTION
ProductLine: Voyager
Release: v2022.06.20
Release-tracker: https://github.com/voyagermesh/CHANGELOG/pull/19
Signed-off-by: 1gtm <1gtm@appscode.com>