### PR TITLE
Prepare for release v2022.12.11

### DIFF
--- a/docs/CHANGELOG-v2022.12.11.md
+++ b/docs/CHANGELOG-v2022.12.11.md
@@ -1,0 +1,71 @@
+---
+title: Changelog | Voyager
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-voyager-v2022.12.11
+    name: Changelog-v2022.12.11
+    parent: welcome
+    weight: 20221211
+product_name: voyager
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2022.12.11/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2022.12.11/
+---
+
+# Voyager v2022.12.11 (2022-12-10)
+
+
+## [voyagermesh/apimachinery](https://github.com/voyagermesh/apimachinery)
+
+### [v0.7.0](https://github.com/voyagermesh/apimachinery/releases/tag/v0.7.0)
+
+- [03ca8808](https://github.com/voyagermesh/apimachinery/commit/03ca8808) Update deps
+- [6e495f8a](https://github.com/voyagermesh/apimachinery/commit/6e495f8a) Run GH actions on ubuntu-20.04 (#34)
+- [e54c78b8](https://github.com/voyagermesh/apimachinery/commit/e54c78b8) Test against Kubernetes 1.25.0 (#33)
+- [aaa19a94](https://github.com/voyagermesh/apimachinery/commit/aaa19a94) Use Go 1.19 (#32)
+- [11bcee3c](https://github.com/voyagermesh/apimachinery/commit/11bcee3c) Use k8s 1.25.1 libs (#31)
+
+
+
+## [voyagermesh/cli](https://github.com/voyagermesh/cli)
+
+### [v0.0.11](https://github.com/voyagermesh/cli/releases/tag/v0.0.11)
+
+- [ee6eb0d](https://github.com/voyagermesh/cli/commit/ee6eb0d) Prepare for release v0.0.11 (#17)
+- [7bf2e36](https://github.com/voyagermesh/cli/commit/7bf2e36) Run GH actions on ubuntu-20.04 (#16)
+- [d597ca1](https://github.com/voyagermesh/cli/commit/d597ca1) Stop using ioutil (#15)
+- [38e08ab](https://github.com/voyagermesh/cli/commit/38e08ab) Use k8s 1.25.1 libs (#14)
+
+
+
+## [voyagermesh/haproxy-ingress](https://github.com/voyagermesh/haproxy-ingress)
+
+### [v17.0.0](https://github.com/voyagermesh/haproxy-ingress/releases/tag/v17.0.0)
+
+- [b9e3daaa](https://github.com/voyagermesh/haproxy-ingress/commit/b9e3daaa4) Prepare for release v17.0.0 (#59)
+- [cf06e700](https://github.com/voyagermesh/haproxy-ingress/commit/cf06e700c) Remove vulnerable deps
+- [3370de4f](https://github.com/voyagermesh/haproxy-ingress/commit/3370de4f0) Run GH actions on ubuntu-20.04 (#58)
+- [ccaa9278](https://github.com/voyagermesh/haproxy-ingress/commit/ccaa9278e) Acquire license from proxyserver (#57)
+- [3b86fefe](https://github.com/voyagermesh/haproxy-ingress/commit/3b86fefef) Update KIND (#56)
+- [a407ff28](https://github.com/voyagermesh/haproxy-ingress/commit/a407ff284) Use Go 1.19 (#55)
+- [d53c24dc](https://github.com/voyagermesh/haproxy-ingress/commit/d53c24dce) Use k8s 1.25.1 libs (#54)
+- [c9db24b2](https://github.com/voyagermesh/haproxy-ingress/commit/c9db24b25) Fix CVE-2022-27664
+
+
+
+## [voyagermesh/installer](https://github.com/voyagermesh/installer)
+
+### [v2022.12.11](https://github.com/voyagermesh/installer/releases/tag/v2022.12.11)
+
+- [d8dd39f](https://github.com/voyagermesh/installer/commit/d8dd39f) Prepare for release v2022.12.11 (#120)
+- [0f1c6c1](https://github.com/voyagermesh/installer/commit/0f1c6c1) Update kubectl version
+- [8decf70](https://github.com/voyagermesh/installer/commit/8decf70) Run GH actions on ubuntu-20.04 (#119)
+- [cd18ec8](https://github.com/voyagermesh/installer/commit/cd18ec8) Test against Kubernetes 1.25.0 (#118)
+- [18fefdf](https://github.com/voyagermesh/installer/commit/18fefdf) Use Go 1.19 (#117)
+
+
+
+


### PR DESCRIPTION
ProductLine: Voyager
Release: v2022.12.11
Release-tracker: https://github.com/voyagermesh/CHANGELOG/pull/23
Signed-off-by: 1gtm <1gtm@appscode.com>