### PR TITLE
Prepare for release v2023.02.22

### DIFF
--- a/docs/CHANGELOG-v2023.02.22.md
+++ b/docs/CHANGELOG-v2023.02.22.md
@@ -1,0 +1,58 @@
+---
+title: Changelog | Voyager
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-voyager-v2023.02.22
+    name: Changelog-v2023.02.22
+    parent: welcome
+    weight: 20230222
+product_name: voyager
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2023.02.22/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2023.02.22/
+---
+
+# Voyager v2023.02.22 (2023-02-23)
+
+
+## [voyagermesh/apimachinery](https://github.com/voyagermesh/apimachinery)
+
+### [v0.7.1](https://github.com/voyagermesh/apimachinery/releases/tag/v0.7.1)
+
+- [8aa11417](https://github.com/voyagermesh/apimachinery/commit/8aa11417) Update dependencies (#35)
+
+
+
+## [voyagermesh/cli](https://github.com/voyagermesh/cli)
+
+### [v0.0.12](https://github.com/voyagermesh/cli/releases/tag/v0.0.12)
+
+- [4e9c89e](https://github.com/voyagermesh/cli/commit/4e9c89e) Prepare for release v0.0.12 (#18)
+
+
+
+## [voyagermesh/haproxy-ingress](https://github.com/voyagermesh/haproxy-ingress)
+
+### [v17.0.1](https://github.com/voyagermesh/haproxy-ingress/releases/tag/v17.0.1)
+
+- [663cfff4](https://github.com/voyagermesh/haproxy-ingress/commit/663cfff4b) Prepare for release v17.0.1 (#61)
+- [7aa174bc](https://github.com/voyagermesh/haproxy-ingress/commit/7aa174bc7) Update dependencies
+- [ece0471a](https://github.com/voyagermesh/haproxy-ingress/commit/ece0471ae) Update submodules
+- [ea8416d3](https://github.com/voyagermesh/haproxy-ingress/commit/ea8416d32) Fix NPE using licenseproxy-server (#60)
+- [e65b1682](https://github.com/voyagermesh/haproxy-ingress/commit/e65b16829) Fix NPE using licenseproxy-server (#60)
+
+
+
+## [voyagermesh/installer](https://github.com/voyagermesh/installer)
+
+### [v2023.02.22](https://github.com/voyagermesh/installer/releases/tag/v2023.02.22)
+
+- [e1d3789](https://github.com/voyagermesh/installer/commit/e1d3789) Prepare for release v2023.02.22 (#121)
+- [7451bba](https://github.com/voyagermesh/installer/commit/7451bba) Publish helm charts as OCI artifacts
+
+
+
+


### PR DESCRIPTION
ProductLine: Voyager
Release: v2023.02.22
Release-tracker: https://github.com/voyagermesh/CHANGELOG/pull/24
Signed-off-by: 1gtm <1gtm@appscode.com>