### PR TITLE
Prepare for release v2023.05.16

### DIFF
--- a/docs/CHANGELOG-v2023.05.16.md
+++ b/docs/CHANGELOG-v2023.05.16.md
@@ -1,0 +1,74 @@
+---
+title: Changelog | Voyager
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-voyager-v2023.05.16
+    name: Changelog-v2023.05.16
+    parent: welcome
+    weight: 20230516
+product_name: voyager
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2023.05.16/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2023.05.16/
+---
+
+# Voyager v2023.05.16 (2023-05-16)
+
+
+## [voyagermesh/apimachinery](https://github.com/voyagermesh/apimachinery)
+
+### [v0.7.2](https://github.com/voyagermesh/apimachinery/releases/tag/v0.7.2)
+
+- [d3eab942](https://github.com/voyagermesh/apimachinery/commit/d3eab942) Update deps
+- [d741654b](https://github.com/voyagermesh/apimachinery/commit/d741654b) Test against K8s 1.27.1 (#40)
+- [f17a74a0](https://github.com/voyagermesh/apimachinery/commit/f17a74a0) Use uid 65534 and test against K8s 1.27.0 (#39)
+- [5313fa2b](https://github.com/voyagermesh/apimachinery/commit/5313fa2b) Use ghcr.io/appscode/gengo (#38)
+- [3cf19792](https://github.com/voyagermesh/apimachinery/commit/3cf19792) Use ghcr.io for appscode/golang-dev (#37)
+- [882d1506](https://github.com/voyagermesh/apimachinery/commit/882d1506) Update wrokflows (Go 1.20, k8s 1.26) (#36)
+
+
+
+## [voyagermesh/cli](https://github.com/voyagermesh/cli)
+
+### [v0.0.13](https://github.com/voyagermesh/cli/releases/tag/v0.0.13)
+
+- [8941c49](https://github.com/voyagermesh/cli/commit/8941c49) Prepare for release v0.0.13 (#21)
+- [2704ce0](https://github.com/voyagermesh/cli/commit/2704ce0) Use ghcr.io for appscode/golang-dev (#20)
+- [c059723](https://github.com/voyagermesh/cli/commit/c059723) Update wrokflows (Go 1.20, k8s 1.26) (#19)
+
+
+
+## [voyagermesh/haproxy-ingress](https://github.com/voyagermesh/haproxy-ingress)
+
+### [v17.0.2](https://github.com/voyagermesh/haproxy-ingress/releases/tag/v17.0.2)
+
+- [e1ec6dc2](https://github.com/voyagermesh/haproxy-ingress/commit/e1ec6dc2b) Prepare for release v17.0.2 (#66)
+- [50755363](https://github.com/voyagermesh/haproxy-ingress/commit/50755363b) Use HAProxy 2.6.12 (#65)
+- [ad1af389](https://github.com/voyagermesh/haproxy-ingress/commit/ad1af389d) Publish to ghcr.io (#64)
+- [b52228b5](https://github.com/voyagermesh/haproxy-ingress/commit/b52228b56) Add docker image label
+- [dcde7f21](https://github.com/voyagermesh/haproxy-ingress/commit/dcde7f21f) Use ghcr.io for appscode/golang-dev (#63)
+- [f46f506d](https://github.com/voyagermesh/haproxy-ingress/commit/f46f506da) Update wrokflows (Go 1.20, k8s 1.26) (#62)
+
+
+
+## [voyagermesh/installer](https://github.com/voyagermesh/installer)
+
+### [v2023.05.16](https://github.com/voyagermesh/installer/releases/tag/v2023.05.16)
+
+- [fabe300](https://github.com/voyagermesh/installer/commit/fabe300) Prepare for release v2023.05.16 (#131)
+- [1f818ff](https://github.com/voyagermesh/installer/commit/1f818ff) Use kubectl 1.24
+- [f1f56c3](https://github.com/voyagermesh/installer/commit/f1f56c3) Test against K8s 1.27.1 (#130)
+- [fa3a42c](https://github.com/voyagermesh/installer/commit/fa3a42c) Use uid 65534 and test against K8s 1.27.0 (#129)
+- [59d0d9a](https://github.com/voyagermesh/installer/commit/59d0d9a) Use ghcr.io/appscode/gengo (#128)
+- [f2ffd5a](https://github.com/voyagermesh/installer/commit/f2ffd5a) Stop publishing oci images to docker hub
+- [9ef2b81](https://github.com/voyagermesh/installer/commit/9ef2b81) Use ghcr.io (#127)
+- [c44f262](https://github.com/voyagermesh/installer/commit/c44f262) Use ghcr.io for appscode/golang-dev (#126)
+- [d40e2fb](https://github.com/voyagermesh/installer/commit/d40e2fb) Update workflows (Go 1.20, k8s 1.26) (#125)
+- [371fe3f](https://github.com/voyagermesh/installer/commit/371fe3f) Update wrokflows (Go 1.20, k8s 1.26) (#124)
+
+
+
+


### PR DESCRIPTION
ProductLine: Voyager
Release: v2023.05.16
Release-tracker: https://github.com/voyagermesh/CHANGELOG/pull/27
Signed-off-by: 1gtm <1gtm@appscode.com>