### PR TITLE
Prepare for release v2023.9.18

### DIFF
--- a/docs/CHANGELOG-v2023.9.18.md
+++ b/docs/CHANGELOG-v2023.9.18.md
@@ -1,0 +1,64 @@
+---
+title: Changelog | Voyager
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-voyager-v2023.9.18
+    name: Changelog-v2023.9.18
+    parent: welcome
+    weight: 20230918
+product_name: voyager
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2023.9.18/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2023.9.18/
+---
+
+# Voyager v2023.9.18 (2023-09-17)
+
+
+## [voyagermesh/apimachinery](https://github.com/voyagermesh/apimachinery)
+
+### [v0.7.3](https://github.com/voyagermesh/apimachinery/releases/tag/v0.7.3)
+
+- [7a511cc9](https://github.com/voyagermesh/apimachinery/commit/7a511cc9) Support custom ssl chipher annotation
+- [757c19c1](https://github.com/voyagermesh/apimachinery/commit/757c19c1) Update license verifier (#41)
+
+
+
+## [voyagermesh/cli](https://github.com/voyagermesh/cli)
+
+### [v0.0.14](https://github.com/voyagermesh/cli/releases/tag/v0.0.14)
+
+- [d137c94](https://github.com/voyagermesh/cli/commit/d137c94) Prepare for release v0.0.14 (#22)
+
+
+
+## [voyagermesh/haproxy-ingress](https://github.com/voyagermesh/haproxy-ingress)
+
+### [v17.0.3](https://github.com/voyagermesh/haproxy-ingress/releases/tag/v17.0.3)
+
+- [8ac3587f](https://github.com/voyagermesh/haproxy-ingress/commit/8ac3587fb) Prepare for release v17.0.3 (#70)
+- [0c7e59b3](https://github.com/voyagermesh/haproxy-ingress/commit/0c7e59b35) update haproxy template
+- [f97e23e0](https://github.com/voyagermesh/haproxy-ingress/commit/f97e23e0d) Support custom ssl chipher (#69)
+- [e461f0bc](https://github.com/voyagermesh/haproxy-ingress/commit/e461f0bc2) Update license verifier (#67)
+- [5f4fb903](https://github.com/voyagermesh/haproxy-ingress/commit/5f4fb9032) Delete docker image is commit is not tagged
+
+
+
+## [voyagermesh/installer](https://github.com/voyagermesh/installer)
+
+### [v2023.9.18](https://github.com/voyagermesh/installer/releases/tag/v2023.9.18)
+
+- [7189d8a](https://github.com/voyagermesh/installer/commit/7189d8a) Prepare for release v2023.9.18 (#135)
+- [2216fd3](https://github.com/voyagermesh/installer/commit/2216fd3) Handle charts without doc.yaml
+- [576f837](https://github.com/voyagermesh/installer/commit/576f837) Update gateway 0.5.0 crds
+- [8044712](https://github.com/voyagermesh/installer/commit/8044712) Use gateway v0.0.2
+- [2bc3aa6](https://github.com/voyagermesh/installer/commit/2bc3aa6) Upgrade to release/v0.5 (#134)
+- [7fafdeb](https://github.com/voyagermesh/installer/commit/7fafdeb) Remove non crd objects from crds folder
+- [677b93d](https://github.com/voyagermesh/installer/commit/677b93d) Use helm repo version
+
+
+
+


### PR DESCRIPTION
ProductLine: Voyager
Release: v2023.9.18
Release-tracker: https://github.com/voyagermesh/CHANGELOG/pull/28
Signed-off-by: 1gtm <1gtm@appscode.com>