### PR TITLE
Prepare for release v2024.3.18

### DIFF
--- a/docs/CHANGELOG-v2024.3.18.md
+++ b/docs/CHANGELOG-v2024.3.18.md
@@ -1,0 +1,67 @@
+---
+title: Changelog | Voyager
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-voyager-v2024.3.18
+    name: Changelog-v2024.3.18
+    parent: welcome
+    weight: 20240318
+product_name: voyager
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2024.3.18/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2024.3.18/
+---
+
+# Voyager v2024.3.18 (2024-03-18)
+
+
+## [voyagermesh/apimachinery](https://github.com/voyagermesh/apimachinery)
+
+### [v0.8.0](https://github.com/voyagermesh/apimachinery/releases/tag/v0.8.0)
+
+- [5baa586c](https://github.com/voyagermesh/apimachinery/commit/5baa586c) Update deps
+- [dbb90e92](https://github.com/voyagermesh/apimachinery/commit/dbb90e92) Use Go 1.22 (#45)
+- [d50e1045](https://github.com/voyagermesh/apimachinery/commit/d50e1045) Update deps (#44)
+- [b98cecb9](https://github.com/voyagermesh/apimachinery/commit/b98cecb9) Use k8s 1.29 client libs (#43)
+- [06618b9e](https://github.com/voyagermesh/apimachinery/commit/06618b9e) Update deps
+
+
+
+## [voyagermesh/cli](https://github.com/voyagermesh/cli)
+
+### [v0.0.15](https://github.com/voyagermesh/cli/releases/tag/v0.0.15)
+
+- [99baac8](https://github.com/voyagermesh/cli/commit/99baac8) Prepare for release v0.0.15 (#24)
+- [586acaf](https://github.com/voyagermesh/cli/commit/586acaf) Use Go 1.22 (#23)
+
+
+
+## [voyagermesh/haproxy-ingress](https://github.com/voyagermesh/haproxy-ingress)
+
+### [v17.1.0](https://github.com/voyagermesh/haproxy-ingress/releases/tag/v17.1.0)
+
+- [04b22e90](https://github.com/voyagermesh/haproxy-ingress/commit/04b22e905) Prepare for release v17.1.0 (#83)
+- [d12ccf31](https://github.com/voyagermesh/haproxy-ingress/commit/d12ccf311) Use haproxy 2.6.16
+- [90e5842a](https://github.com/voyagermesh/haproxy-ingress/commit/90e5842af) Update deps
+- [8ce183c7](https://github.com/voyagermesh/haproxy-ingress/commit/8ce183c7d) Use Go 1.22 (#82)
+- [4ed0abc5](https://github.com/voyagermesh/haproxy-ingress/commit/4ed0abc5f) Update deps (#79)
+- [c43d785c](https://github.com/voyagermesh/haproxy-ingress/commit/c43d785cd) Use k8s 1.29 client libs (#76)
+- [a832564a](https://github.com/voyagermesh/haproxy-ingress/commit/a832564ad) Send hourly audit events (#75)
+- [d2b57c9d](https://github.com/voyagermesh/haproxy-ingress/commit/d2b57c9da) Update deps
+- [664aa057](https://github.com/voyagermesh/haproxy-ingress/commit/664aa0578) Disable cleanup of image
+
+
+
+## [voyagermesh/installer](https://github.com/voyagermesh/installer)
+
+### [v2024.3.18](https://github.com/voyagermesh/installer/releases/tag/v2024.3.18)
+
+- [32154e1](https://github.com/voyagermesh/installer/commit/32154e1) Prepare for release v2024.3.18 (#139)
+- [18d19e2](https://github.com/voyagermesh/installer/commit/18d19e2) Use Go 1.22 (#138)
+
+
+
+


### PR DESCRIPTION
ProductLine: Voyager
Release: v2024.3.18
Release-tracker: https://github.com/voyagermesh/CHANGELOG/pull/29
Signed-off-by: 1gtm <1gtm@appscode.com>