### PR TITLE
Prepare for release v2024.8.30

### DIFF
--- a/docs/CHANGELOG-v2024.8.30.md
+++ b/docs/CHANGELOG-v2024.8.30.md
@@ -1,0 +1,60 @@
+---
+title: Changelog | Voyager
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-voyager-v2024.8.30
+    name: Changelog-v2024.8.30
+    parent: welcome
+    weight: 20240830
+product_name: voyager
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2024.8.30/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2024.8.30/
+---
+
+# Voyager v2024.8.30 (2024-08-30)
+
+
+## [voyagermesh/apimachinery](https://github.com/voyagermesh/apimachinery)
+
+### [v0.9.0](https://github.com/voyagermesh/apimachinery/releases/tag/v0.9.0)
+
+- [71a6c1ad](https://github.com/voyagermesh/apimachinery/commit/71a6c1ad) Update deps
+- [89bcb169](https://github.com/voyagermesh/apimachinery/commit/89bcb169) Use Go 1.23 (#47)
+- [44f5114c](https://github.com/voyagermesh/apimachinery/commit/44f5114c) Test against k8s 1.31 (#46)
+
+
+
+## [voyagermesh/cli](https://github.com/voyagermesh/cli)
+
+### [v0.0.16](https://github.com/voyagermesh/cli/releases/tag/v0.0.16)
+
+- [f49035e](https://github.com/voyagermesh/cli/commit/f49035e) Prepare for release v0.0.16 (#26)
+- [9e7e638](https://github.com/voyagermesh/cli/commit/9e7e638) Use Go 1.23 (#25)
+
+
+
+## [voyagermesh/haproxy-ingress](https://github.com/voyagermesh/haproxy-ingress)
+
+### [v17.2.0](https://github.com/voyagermesh/haproxy-ingress/releases/tag/v17.2.0)
+
+- [2aa4c0d4](https://github.com/voyagermesh/haproxy-ingress/commit/2aa4c0d46) Prepare for release v17.2.0 (#90)
+- [5066badd](https://github.com/voyagermesh/haproxy-ingress/commit/5066badd0) Use 2.9.9-alpine
+- [1443e60d](https://github.com/voyagermesh/haproxy-ingress/commit/1443e60d4) Update deps (#89)
+- [7baa24f1](https://github.com/voyagermesh/haproxy-ingress/commit/7baa24f15) Use Go 1.23 (#87)
+
+
+
+## [voyagermesh/installer](https://github.com/voyagermesh/installer)
+
+### [v2024.8.30](https://github.com/voyagermesh/installer/releases/tag/v2024.8.30)
+
+- [0b87060](https://github.com/voyagermesh/installer/commit/0b87060) Prepare for release v2024.8.30 (#142)
+- [05d4096](https://github.com/voyagermesh/installer/commit/05d4096) Use Go 1.23 (#140)
+
+
+
+


### PR DESCRIPTION
ProductLine: Voyager
Release: v2024.8.30
Release-tracker: https://github.com/voyagermesh/CHANGELOG/pull/32
Signed-off-by: 1gtm <1gtm@appscode.com>