### PR TITLE
Prepare for release v2025.5.30

### DIFF
--- a/docs/CHANGELOG-v2025.5.30.md
+++ b/docs/CHANGELOG-v2025.5.30.md
@@ -1,0 +1,78 @@
+---
+title: Changelog | Voyager
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-voyager-v2025.5.30
+    name: Changelog-v2025.5.30
+    parent: welcome
+    weight: 20250530
+product_name: voyager
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2025.5.30/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2025.5.30/
+---
+
+# Voyager v2025.5.30 (2025-05-29)
+
+
+## [voyagermesh/apimachinery](https://github.com/voyagermesh/apimachinery)
+
+### [v0.10.0](https://github.com/voyagermesh/apimachinery/releases/tag/v0.10.0)
+
+- [ad02f517](https://github.com/voyagermesh/apimachinery/commit/ad02f517e) Use k8s client-go 1.32
+- [9abd2ba4](https://github.com/voyagermesh/apimachinery/commit/9abd2ba44) Test against k8s 1.32 (#60)
+- [2314a346](https://github.com/voyagermesh/apimachinery/commit/2314a3462) Test against k8s 1.32 (#59)
+- [bba1cdea](https://github.com/voyagermesh/apimachinery/commit/bba1cdea3) Test against k8s 1.32 (#58)
+- [951aa6e0](https://github.com/voyagermesh/apimachinery/commit/951aa6e01) Test against k8s 1.32 (#57)
+- [4b28e174](https://github.com/voyagermesh/apimachinery/commit/4b28e174b) Test against k8s 1.32 (#56)
+- [b7c63f29](https://github.com/voyagermesh/apimachinery/commit/b7c63f298) Use Go 1.24 (#54)
+- [00787859](https://github.com/voyagermesh/apimachinery/commit/007878597) Use Go 1.24 (#53)
+- [4e7b3a84](https://github.com/voyagermesh/apimachinery/commit/4e7b3a84b) Disable image caching in setup-qemu action (#52)
+- [0ee53f07](https://github.com/voyagermesh/apimachinery/commit/0ee53f073) Update deps
+- [9d4cb4c0](https://github.com/voyagermesh/apimachinery/commit/9d4cb4c0c) Update github action modules (#51)
+- [1b9575cd](https://github.com/voyagermesh/apimachinery/commit/1b9575cd1) Use kind v0.25.0 (#50)
+- [4b07a1eb](https://github.com/voyagermesh/apimachinery/commit/4b07a1eb6) Use debian:12 base image (#49)
+- [246ffc3c](https://github.com/voyagermesh/apimachinery/commit/246ffc3cf) Use KIND v0.24.0 (#48)
+
+
+
+## [voyagermesh/cli](https://github.com/voyagermesh/cli)
+
+### [v0.0.17](https://github.com/voyagermesh/cli/releases/tag/v0.0.17)
+
+- [1a977cd](https://github.com/voyagermesh/cli/commit/1a977cd) Prepare for release v0.0.17 (#30)
+- [baee384](https://github.com/voyagermesh/cli/commit/baee384) Use Go 1.24 (#29)
+- [f72fce6](https://github.com/voyagermesh/cli/commit/f72fce6) Disable image caching in setup-qemu action (#28)
+- [feadeef](https://github.com/voyagermesh/cli/commit/feadeef) Update github action modules (#27)
+
+
+
+## [voyagermesh/haproxy-ingress](https://github.com/voyagermesh/haproxy-ingress)
+
+### [v17.3.0](https://github.com/voyagermesh/haproxy-ingress/releases/tag/v17.3.0)
+
+- [517279ac](https://github.com/voyagermesh/haproxy-ingress/commit/517279ac2) Prepare for release v17.3.0 (#101)
+- [5036b3be](https://github.com/voyagermesh/haproxy-ingress/commit/5036b3bee) Use k8s 1.32 client libs (#100)
+- [9030de41](https://github.com/voyagermesh/haproxy-ingress/commit/9030de410) Test against k8s 1.32 (#99)
+- [82a1cae0](https://github.com/voyagermesh/haproxy-ingress/commit/82a1cae0a) Use Go 1.24 (#97)
+- [0dd48afd](https://github.com/voyagermesh/haproxy-ingress/commit/0dd48afd9) Use Go 1.24 (#96)
+- [af58f92b](https://github.com/voyagermesh/haproxy-ingress/commit/af58f92b0) Disable image caching in setup-qemu action (#95)
+- [e3ee7970](https://github.com/voyagermesh/haproxy-ingress/commit/e3ee7970a) Update github action modules (#94)
+- [31bc4351](https://github.com/voyagermesh/haproxy-ingress/commit/31bc43511) Use kind v0.25.0 (#93)
+- [e9e52770](https://github.com/voyagermesh/haproxy-ingress/commit/e9e527700) Use KIND v0.24.0 (#91)
+
+
+
+## [voyagermesh/installer](https://github.com/voyagermesh/installer)
+
+### [v2025.5.30](https://github.com/voyagermesh/installer/releases/tag/v2025.5.30)
+
+- [c5f041f9](https://github.com/voyagermesh/installer/commit/c5f041f9) Prepare for release v2025.5.30 (#176)
+- [94d2eafd](https://github.com/voyagermesh/installer/commit/94d2eafd) Use k8s 1.32 client libs
+
+
+
+


### PR DESCRIPTION
ProductLine: Voyager
Release: v2025.5.30
Release-tracker: https://github.com/voyagermesh/CHANGELOG/pull/36
Signed-off-by: 1gtm <1gtm@appscode.com>