### PR TITLE
Prepare for release v2025.9.19

### DIFF
--- a/docs/CHANGELOG-v2025.9.19.md
+++ b/docs/CHANGELOG-v2025.9.19.md
@@ -1,0 +1,68 @@
+---
+title: Changelog | Voyager
+description: Changelog
+menu:
+  docs_{{.version}}:
+    identifier: changelog-voyager-v2025.9.19
+    name: Changelog-v2025.9.19
+    parent: welcome
+    weight: 20250919
+product_name: voyager
+menu_name: docs_{{.version}}
+section_menu_id: welcome
+url: /docs/{{.version}}/welcome/changelog-v2025.9.19/
+aliases:
+  - /docs/{{.version}}/CHANGELOG-v2025.9.19/
+---
+
+# Voyager v2025.9.19 (2025-09-18)
+
+
+## [voyagermesh/apimachinery](https://github.com/voyagermesh/apimachinery)
+
+### [v0.11.0](https://github.com/voyagermesh/apimachinery/releases/tag/v0.11.0)
+
+- [3af07a16](https://github.com/voyagermesh/apimachinery/commit/3af07a166) Update deps
+- [dc2062f7](https://github.com/voyagermesh/apimachinery/commit/dc2062f74) Test against k8s 1.34 (#65)
+- [93f38001](https://github.com/voyagermesh/apimachinery/commit/93f380017) Use Go 1.25 (#64)
+- [e8b7b670](https://github.com/voyagermesh/apimachinery/commit/e8b7b6703) Test against k8s 1.33.2 (#63)
+- [d882173b](https://github.com/voyagermesh/apimachinery/commit/d882173bc) Test against k8s 1.33.2 (#62)
+- [b07639e3](https://github.com/voyagermesh/apimachinery/commit/b07639e34) Test against k8s 1.33 (#61)
+
+
+
+## [voyagermesh/cli](https://github.com/voyagermesh/cli)
+
+### [v0.0.18](https://github.com/voyagermesh/cli/releases/tag/v0.0.18)
+
+- [d2b6c79](https://github.com/voyagermesh/cli/commit/d2b6c79) Prepare for release v0.0.18 (#32)
+- [24dacfc](https://github.com/voyagermesh/cli/commit/24dacfc) Use Go 1.25 (#31)
+
+
+
+## [voyagermesh/haproxy-ingress](https://github.com/voyagermesh/haproxy-ingress)
+
+### [v17.4.0](https://github.com/voyagermesh/haproxy-ingress/releases/tag/v17.4.0)
+
+- [ea52ab6e](https://github.com/voyagermesh/haproxy-ingress/commit/ea52ab6ee) Prepare for release v17.4.0 (#109)
+- [76a18da4](https://github.com/voyagermesh/haproxy-ingress/commit/76a18da42) Update deps
+- [80a39de7](https://github.com/voyagermesh/haproxy-ingress/commit/80a39de7c) Test against k8s 1.34 (#108)
+- [1acd1aa3](https://github.com/voyagermesh/haproxy-ingress/commit/1acd1aa37) Use Go 1.25 (#106)
+- [27974ffa](https://github.com/voyagermesh/haproxy-ingress/commit/27974ffa0) Test against k8s 1.33.2 (#104)
+- [0232b7dd](https://github.com/voyagermesh/haproxy-ingress/commit/0232b7dd8) Test against k8s 1.33 (#103)
+
+
+
+## [voyagermesh/installer](https://github.com/voyagermesh/installer)
+
+### [v2025.9.19](https://github.com/voyagermesh/installer/releases/tag/v2025.9.19)
+
+- [1abdfb32](https://github.com/voyagermesh/installer/commit/1abdfb32) Prepare for release v2025.9.19 (#187)
+- [3368908a](https://github.com/voyagermesh/installer/commit/3368908a) Test against k8s 1.34 (#184)
+- [579f372f](https://github.com/voyagermesh/installer/commit/579f372f) Use Go 1.25 (#183)
+- [ab1f844f](https://github.com/voyagermesh/installer/commit/ab1f844f) Test against k8s 1.33.2 (#181)
+- [acf65424](https://github.com/voyagermesh/installer/commit/acf65424) Test against k8s 1.33 (#180)
+
+
+
+


### PR DESCRIPTION
ProductLine: Voyager
Release: v2025.9.19
Release-tracker: https://github.com/voyagermesh/CHANGELOG/pull/38
Signed-off-by: 1gtm <1gtm@appscode.com>